### PR TITLE
workflows: temporarily re-add Perl 5.36 for proper rebuild

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -20,6 +20,7 @@ jobs:
           - tag: 5.42-slim-bookworm
           - tag: 5.40-slim-bookworm
           - tag: 5.38-slim-bookworm
+          - tag: 5.36-slim-bookworm
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
To be removed in next update.